### PR TITLE
Ensure static entries don't block dynamic entries

### DIFF
--- a/validator-firewall-ebpf/src/main.rs
+++ b/validator-firewall-ebpf/src/main.rs
@@ -18,10 +18,11 @@ use network_types::{
     udp::UdpHdr,
 };
 
+const DENY_LIST_SIZE: u32 = 524288;
 
 //These are our data structures that we use to communicate with userspace
 #[map(name = "hvf_deny_list")]
-static LEADER_SLOT_DENY_LIST: HashMap<u32, u8> = HashMap::<u32, u8>::with_max_entries(8192, 0);
+static LEADER_SLOT_DENY_LIST: HashMap<u32, u8> = HashMap::<u32, u8>::with_max_entries(DENY_LIST_SIZE, 0);
 #[map(name = "hvf_always_allow")]
 static FULL_SCHEDULE_ALLOW_LIST: HashMap<u32, u8> = HashMap::<u32, u8>::with_max_entries(8192, 0);
 #[map(name = "hvf_stats")]

--- a/validator-firewall/src/ip_service_main.rs
+++ b/validator-firewall/src/ip_service_main.rs
@@ -76,7 +76,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let app_state = Arc::new(IPState::new());
 
-
     for node in static_overrides.0.iter() {
         app_state.add_http_node(node.clone()).await;
     }

--- a/validator-firewall/src/leader_tracker.rs
+++ b/validator-firewall/src/leader_tracker.rs
@@ -1,10 +1,10 @@
-use std::ops::Range;
 use aya::maps::{Array, Map};
 use log::{error, info, warn};
 use rangemap::RangeInclusiveSet;
 use solana_rpc_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_sdk::epoch_info::EpochInfo;
+use std::ops::Range;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -181,7 +181,6 @@ impl RPCLeaderTracker {
                     let mut leader_ranges: RangeInclusiveSet<u64, u64> = RangeInclusiveSet::new();
                     for slot in my_slots {
                         let end: u64 = *slot as u64;
-
 
                         let range = end.saturating_sub(self.slot_buffer)..=end;
                         leader_ranges.insert(range);

--- a/validator-firewall/src/main.rs
+++ b/validator-firewall/src/main.rs
@@ -5,7 +5,10 @@ mod config;
 mod leader_tracker;
 
 use crate::config::{load_static_overrides, NameAddressPair};
-use crate::ip_service::{ DenyListService, DenyListStateUpdater, HttpDenyListClient, DuckDbDenyListClient, NoOpDenyListClient};
+use crate::ip_service::{
+    DenyListService, DenyListStateUpdater, DuckDbDenyListClient, HttpDenyListClient,
+    NoOpDenyListClient,
+};
 use crate::leader_tracker::{CommandControlService, RPCLeaderTracker};
 use anyhow::Context;
 use aya::{
@@ -154,9 +157,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
         let s_updater = DenyListStateUpdater::new(
             gossip_exit,
-            Arc::new(DenyListService::new(DuckDbDenyListClient::new(
-                query,
-            ))),
+            Arc::new(DenyListService::new(DuckDbDenyListClient::new(query))),
             static_overrides.clone(),
         );
 
@@ -187,7 +188,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let tracker = Arc::new(RPCLeaderTracker::new(
         exit.clone(),
         RpcClient::new(config.rpc_endpoint.clone()),
-        10,
+        12,
         config.leader_id,
     ));
     let bg_tracker = tracker.clone();


### PR DESCRIPTION
There was an issue during troubleshooting where the static overrides exhausted the space available in the map for dynamic entries.  This reserves a buffer for incoming entries.

Also, move leader tracking slot buffer to 12 from 10.